### PR TITLE
Austin user validation attributes

### DIFF
--- a/MockWebApi.UnitTests/MockWebApi.UnitTests.csproj
+++ b/MockWebApi.UnitTests/MockWebApi.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -17,7 +17,7 @@ namespace MongoDA
 
         [DataMember(Name = "location")]
         [Required (ErrorMessage = "Location is required.")]
-        [StringLength(maximumLength: 32, MinimumLength = 0)]
+        [MaxLength(64, ErrorMessage ="Location must be shorter than 64 characters.")]
         public string Location { get; set; }
 
         [DataMember(Name = "address")]
@@ -42,7 +42,7 @@ namespace MongoDA
 
         [DataMember(Name = "type")]
         [Required (ErrorMessage = "Type is required.")]
-        [StringLength(maximumLength: 32, MinimumLength = 0)]
+        [StringLength(maximumLength: 64, MinimumLength = 0)]
         public string Type { get; set; }
     }
 

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -27,6 +27,7 @@ namespace MongoDA
         [DataMember(Name = "location")]
         [Required (ErrorMessage = "Location is required.")]
         [MaxLength(255, ErrorMessage ="Location must be shorter than 256 characters.")]
+        [RegularExpression("")]
         public string Location { get; set; }
 
         /// <value>Address object of user while in the housing system</value>

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -56,7 +56,7 @@ namespace MongoDA
         /// <value>Type of user; for now, only Associates are implemented.</value>
         [DataMember(Name = "type")]
         [Required (ErrorMessage = "Type is required.")]
-        [StringLength(maximumLength: 255, MinimumLength = 0, ErrorMessage = "Type must be shorter than 256 characters")]
+        [StringLength(maximumLength: 255, MinimumLength = 1, ErrorMessage = "Type must be shorter than 256 characters")]
         public string Type { get; set; }
     }
 

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -17,7 +17,7 @@ namespace MongoDA
 
         [DataMember(Name = "location")]
         [Required (ErrorMessage = "Location is required.")]
-        [MaxLength(64, ErrorMessage ="Location must be shorter than 64 characters.")]
+        [MaxLength(255, ErrorMessage ="Location must be shorter than 256 characters.")]
         public string Location { get; set; }
 
         [DataMember(Name = "address")]
@@ -42,7 +42,7 @@ namespace MongoDA
 
         [DataMember(Name = "type")]
         [Required (ErrorMessage = "Type is required.")]
-        [StringLength(maximumLength: 64, MinimumLength = 0)]
+        [StringLength(maximumLength: 255, MinimumLength = 0, ErrorMessage = "Type must be shorter than 256 characters")]
         public string Type { get; set; }
     }
 

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Text;
 using MongoDB.Bson.Serialization.Attributes;
@@ -11,18 +12,37 @@ namespace MongoDA
     {
         [BsonId]
         [DataMember(Name = "userId")]
+        [Required (ErrorMessage = "User Id is required.")]
         public Guid UserId { get; set; }
+
         [DataMember(Name = "location")]
+        [Required (ErrorMessage = "Location is required.")]
+        [StringLength(maximumLength: 32, MinimumLength = 0)]
         public string Location { get; set; }
+
         [DataMember(Name = "address")]
+        [Required (ErrorMessage = "Address is required.")]
         public Address Address { get; set; }
+
         [DataMember(Name = "email")]
+        [Required (ErrorMessage = "Email is required.")]
+        [EmailAddress (ErrorMessage = "Invalid email format.")]
+        [MaxLength(
+            254,
+            ErrorMessage = "Email must be shorter than 255 characters.")]
         public string Email { get; set; }
+
         [DataMember(Name = "name")]
+        [Required (ErrorMessage = "Name is required.")]
         public Name Name { get; set; }
+
         [DataMember(Name = "gender")]
+        [Required (ErrorMessage = "Name is required.")]
         public char Gender { get; set; }
+
         [DataMember(Name = "type")]
+        [Required (ErrorMessage = "Type is required.")]
+        [StringLength(maximumLength: 32, MinimumLength = 0)]
         public string Type { get; set; }
     }
 

--- a/MongoDA/User.cs
+++ b/MongoDA/User.cs
@@ -27,7 +27,6 @@ namespace MongoDA
         [DataMember(Name = "location")]
         [Required (ErrorMessage = "Location is required.")]
         [MaxLength(255, ErrorMessage ="Location must be shorter than 256 characters.")]
-        [RegularExpression("")]
         public string Location { get; set; }
 
         /// <value>Address object of user while in the housing system</value>

--- a/MongoDA/User.cs.orig
+++ b/MongoDA/User.cs.orig
@@ -7,34 +7,27 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDA
 {
-    /// <summary>
-    /// User model containing all information for a single user.
-    /// </summary>
-    /// <remarks>
-    /// A user refers to a single person in the Revature Housing system.  Currently, this model
-    /// only represents associates in training.
-    /// </remarks>
     [DataContract]
     public class User
     {
-        /// <value>Unique user id</value>
         [BsonId]
         [DataMember(Name = "userId")]
+<<<<<<< HEAD
         [Required (ErrorMessage = "User Id is required.")]
+=======
+        [Required]
+>>>>>>> develop
         public Guid UserId { get; set; }
 
-        /// <value>Training location for this user</value>
         [DataMember(Name = "location")]
         [Required (ErrorMessage = "Location is required.")]
         [MaxLength(255, ErrorMessage ="Location must be shorter than 256 characters.")]
         public string Location { get; set; }
 
-        /// <value>Address object of user while in the housing system</value>
         [DataMember(Name = "address")]
         [Required (ErrorMessage = "Address is required.")]
         public Address Address { get; set; }
 
-        /// <value>Email address of user</value>
         [DataMember(Name = "email")]
         [Required (ErrorMessage = "Email is required.")]
         [EmailAddress (ErrorMessage = "Invalid email format.")]
@@ -43,17 +36,18 @@ namespace MongoDA
             ErrorMessage = "Email must be shorter than 255 characters.")]
         public string Email { get; set; }
 
-        /// <value>Name object of user</value>
         [DataMember(Name = "name")]
         [Required (ErrorMessage = "Name is required.")]
         public Name Name { get; set; }
 
-        /// <value>Gender of user</value>
         [DataMember(Name = "gender")]
-        [Required (ErrorMessage = "Gender is required.")]
-        public string Gender { get; set; }
+<<<<<<< HEAD
+        [Required (ErrorMessage = "Name is required.")]
+        public char Gender { get; set; }
 
-        /// <value>Type of user; for now, only Associates are implemented.</value>
+=======
+        public string Gender { get; set; }
+>>>>>>> develop
         [DataMember(Name = "type")]
         [Required (ErrorMessage = "Type is required.")]
         [StringLength(maximumLength: 255, MinimumLength = 0, ErrorMessage = "Type must be shorter than 256 characters")]


### PR DESCRIPTION
Mostly just required fields for everything.  Length restriction on location, email, and type at 64, 254, and 64 respectively.